### PR TITLE
Add required CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## Summary
- run tests and the production build for every pull request to `main`
- audit production dependencies for high-severity vulnerabilities
- use read-only repository permissions and cancel superseded runs

## Verification
- `npm test` (6 tests pass)
- `npm run build`
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)

This bootstraps the `test` check that the `main` branch ruleset will require for future changes.
