### PR TITLE
docs: starter framing, signup path, and credit terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
-# HarnessRouter Demo at Harvard
+# HarnessRouter Starter
 
-Open-source demo repository for the HarnessRouter workshop at Harvard.
+Open-source starter demos for [HarnessRouter](https://harnessrouter.ai), the unified API for running agent harnesses such as Codex and Claude Code as your product backend.
 
-This repository contains two separate applications. The **Cursor-style coding app is the primary workshop demo**; **LumaCare is a second reference demo** showing how the same HarnessRouter patterns transfer to a different domain.
+An LLM returns tokens. A harness gives it a sandbox, tools, and a loop, so it returns the actual file. HarnessRouter lets your app send a task through one API and get back finished work.
+
+This repository contains two separate applications. The **Cursor-style coding app is the primary demo**; **LumaCare is a second reference demo** showing how the same HarnessRouter patterns transfer to a different domain.
+
+## Get your API key
+
+1. [Create a HarnessRouter account](https://app.harnessrouter.ai/login?ref=github-starter). Signing up is free.
+2. Add a payment card to unlock the 500 free launch credits (limited-time offer).
+3. Follow the [quickstart](https://app.harnessrouter.ai/quickstart?ref=github-starter) to create an API key, and for the primary demo, a coding agent whose agent ID you will reference below.
+
+You can install and start either demo without a card. Credits are only consumed once the app sends tasks through your API key, and both demos run comfortably within the free credits.
 
 ## Demos
 
 ### 1. Cursor-style coding app — primary demo
 
-**Workshop:** Build a Cursor in 3 Steps
-
-A coding-agent interface that demonstrates project-aware tasks, streamed output, persistent sessions, follow-up work, cancellation, and generated-file downloads.
+A coding-agent interface that demonstrates project-aware tasks, streamed output, persistent sessions, follow-up work, cancellation, and generated-file downloads. Watch the [55-second build video](https://harnessrouter.ai/example?ref=github-starter) to see it running.
 
 [Open the Cursor-style demo guide](./demos/01-cursor-coding-app/README.md)
 
@@ -43,7 +51,7 @@ Run one demo at a time because both use port `3000` by default.
 ```text
 .
 ├── demos/
-│   ├── 01-cursor-coding-app/  # Primary Harvard workshop demo
+│   ├── 01-cursor-coding-app/  # Primary demo
 │   └── 02-lumacare/           # Secondary reference demo
 ├── .env.example               # Shared local configuration template
 ├── package.json               # npm workspace commands
@@ -55,7 +63,7 @@ Each demo owns its frontend, server, tests, agent mapping, and documentation. Th
 ## Prerequisites
 
 - Node.js 22 or newer
-- A HarnessRouter API key
+- A HarnessRouter API key (see [Get your API key](#get-your-api-key))
 - A HarnessRouter coding-agent ID for the primary demo
 
 ## Commands
@@ -68,3 +76,9 @@ npm run build        # Build and type-check both workspaces
 ```
 
 Credentials belong in an ignored `.env` file and never in source control. See each demo's README for its configuration and architecture.
+
+## Learn more
+
+- [HarnessRouter website](https://harnessrouter.ai?ref=github-starter)
+- [Documentation](https://harnessrouter.ai/docs?ref=github-starter)
+- [Pricing](https://harnessrouter.ai/pricing?ref=github-starter)

--- a/demos/01-cursor-coding-app/README.md
+++ b/demos/01-cursor-coding-app/README.md
@@ -22,6 +22,8 @@ From the repository root:
    PORT=3000
    ```
 
+   No key yet? Follow [Get your API key](../../README.md#get-your-api-key) in the repository README. Starting the demo consumes no credits; credits are only used when tasks run.
+
 3. Start the primary demo.
 
    ```bash
@@ -40,7 +42,7 @@ Open [http://localhost:3000](http://localhost:3000).
 | `src/App.tsx` | Provides the Cursor-style coding-agent interface and session history |
 | `tests/` | Covers stream parsing and cross-user session ownership |
 
-The demo intentionally does not include a production repository sandbox. Configure the HarnessRouter coding agent with the tools and repository access appropriate to your workshop environment.
+The demo intentionally does not include a production repository sandbox. Configure the HarnessRouter coding agent with the tools and repository access appropriate to your environment.
 
 ## Direct workspace commands
 

--- a/demos/02-lumacare/README.md
+++ b/demos/02-lumacare/README.md
@@ -1,6 +1,6 @@
 # LumaCare
 
-The secondary HarnessRouter reference demo in this repository.
+The secondary HarnessRouter reference demo in this repository, originally built for the HarnessRouter workshop at Harvard.
 
 LumaCare is a family-care companion for parents and caregivers of children receiving cancer care. It demonstrates how the same secure streaming, persistence, ownership, and artifact patterns used by the primary coding demo can support a specialized domain experience.
 

--- a/demos/02-lumacare/README.md
+++ b/demos/02-lumacare/README.md
@@ -9,7 +9,7 @@ LumaCare is a family-care companion for parents and caregivers of children recei
 From the repository root:
 
 1. Run `npm install` if dependencies are not installed.
-2. Copy `.env.example` to the repository root as `.env` and set `HR_API_KEY`.
+2. Copy `.env.example` to the repository root as `.env` and set `HR_API_KEY` (no key yet? Follow [Get your API key](../../README.md#get-your-api-key) in the repository README).
 3. Start the demo:
 
    ```bash


### PR DESCRIPTION
## What changed

- Top-level README reframed from event-scoped ("Demo at Harvard") to the evergreen **HarnessRouter Starter**; the Harvard workshop provenance now lives only inside the two demo READMEs, per positioning guidance.
- New **Get your API key** section closing the acquisition loop: free signup link, the card requirement to unlock the 500-credit launch offer, and the clarification that demos install and start without a card — credits are only consumed when tasks run through the API key.
- Added website / docs / pricing / example-video links with `?ref=github-starter` attribution.
- LumaCare README notes its Harvard workshop origin (the Cursor demo README already did).

Repo settings updated alongside this PR: renamed to `harnessrouter-starter` (old URLs redirect), homepage set to harnessrouter.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)