### PR TITLE
Fix the create-from-template path

### DIFF
--- a/kits/slides/app/src/components/ChatPanel.jsx
+++ b/kits/slides/app/src/components/ChatPanel.jsx
@@ -52,7 +52,8 @@ function turnsToMessages(turns) {
   return m;
 }
 
-export function ChatColumn({ deckId, seed, title, copilotBuilding, collapsed, onToggle, onDeckMaybeChanged, width }) {
+export function ChatColumn({ deckId, seed, title, copilotBuilding, collapsed, onToggle, onDeckMaybeChanged,
+                             onSessionStarted, width }) {
   const [messages, setMessages] = useState([]);
   const [draft, setDraft] = useState('');
   const [attaching, setAttaching] = useState(false);
@@ -129,6 +130,8 @@ export function ChatColumn({ deckId, seed, title, copilotBuilding, collapsed, on
         return;
       }
       const out = await streamTurn(deckId, text, {
+        // A deck created from the landing page has no session until this turn makes one.
+        onSession: (sid) => onSessionStarted?.(sid),
         onReasoningDelta: (d) => updateLastAsst((a) => ({ ...a, blocks: withReasoning(a.blocks, d) })),
         onToolCall: (name, args, callId) => updateLastAsst((a) => ({ ...a, blocks: withStep(a.blocks, { name, args, callId }) })),
         onToolResult: (callId, output) => updateLastAsst((a) => ({ ...a, blocks: withResult(a.blocks, callId, output) })),

--- a/kits/slides/app/src/lib/copilot.js
+++ b/kits/slides/app/src/lib/copilot.js
@@ -10,7 +10,7 @@
 // reported through onSession before being handed to the dispatcher.
 import { createResponsesDispatcher, readSSEStream } from 'reifyui';
 import { authFetch } from './auth';
-import { slidesHarness } from './sl';
+import { getTemplateDetail, slidesHarness } from './sl';
 
 const API = '/api/harness/v1';
 
@@ -30,13 +30,36 @@ export async function streamTurn(deckId, message, h) {
   const harness = await slidesHarness();
   if (!harness) throw new Error('Slides has not been launched yet.');
   // A pending deck id ("new:<template>") is not a session — omit it and let the turn create one.
-  const existing = deckId && !String(deckId).startsWith('new:') ? String(deckId) : '';
+  const pending = String(deckId || '').startsWith('new:');
+  const existing = deckId && !pending ? String(deckId) : '';
+
+  // The template the person picked only exists client-side, so the first turn is where it becomes
+  // real: hand the agent the design brief and the exact theme to build on. Without this the
+  // choice would be silently discarded and every deck would come out looking the same.
+  let input = message;
+  if (pending) {
+    const templateId = String(deckId).slice(4);
+    if (templateId && templateId !== 'blank') {
+      const t = await getTemplateDetail(templateId).catch(() => null);
+      if (t) {
+        input = [
+          `Design this deck in the "${t.name}" style.`,
+          t.context || t.description || '',
+          '',
+          'Use exactly this theme in deck.json:',
+          JSON.stringify(t.theme || {}, null, 2),
+          '',
+          `The brief: ${message}`,
+        ].filter(Boolean).join('\n');
+      }
+    }
+  }
 
   const res = await authFetch(`${API}/responses`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
     body: JSON.stringify({
-      input: message,
+      input,
       metadata: { harness_id: harness.id, ...(existing ? { session_id: existing } : {}) },
       stream: true,
     }),

--- a/kits/slides/app/src/lib/sl.js
+++ b/kits/slides/app/src/lib/sl.js
@@ -109,8 +109,8 @@ export async function listDecks() {
 export async function createDeck(name, template = 'blank') {
   const h = await slidesHarness();
   if (!h) throw new Error('Slides has not been launched yet.');
-  const pending = { deck_id: `new:${template}`, name: name || 'Untitled deck', template };
-  return pending;
+  const id = `new:${template}`;
+  return { id, deck_id: id, name: name || 'Untitled deck', template };
 }
 
 export async function renameDeck(id, name) {

--- a/kits/slides/app/src/pages/DeckPage.jsx
+++ b/kits/slides/app/src/pages/DeckPage.jsx
@@ -80,6 +80,14 @@ export function DeckPage({ id, seed }) {
     onCopilot: setCopilotBusy,
   });
 
+  const adoptSession = useCallback((sid) => {
+    if (!sid || sid === id) return;
+    const [, query = ''] = (window.location.hash || '').split('?');
+    window.history.replaceState({}, '', `#/d/${sid}${query ? `?${query}` : ''}`);
+    // App keys DeckPage on the id, so dispatching the change remounts it against the real session.
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+  }, [id]);
+
   const load = useCallback(() => getDeck(id)
     .then((r) => {
       revRef.current = Number(r.deck?.meta?.rev || 0);
@@ -250,6 +258,7 @@ export function DeckPage({ id, seed }) {
         collapsed={false}
         onToggle={() => {}}
         onDeckMaybeChanged={load}
+        onSessionStarted={adoptSession}
         width={chatPane.width}
       />
 


### PR DESCRIPTION
Found by driving the deployed VM, not by reading: picking a template and hitting
Create landed on `#/d/undefined`.

Three defects on the create path:

- `createDeck` returned `{deck_id}` but every page reads `res.id`.
- Nothing adopted the real session id. A deck starts as `new:<template>` and becomes a
  session when its first turn runs; the id arrives in the stream, so `DeckPage` now swaps
  it into the URL with `replaceState` — not push, since the pending id addresses nothing
  and must not be a Back target.
- The chosen template was discarded entirely. It only exists client-side, so the first
  turn is where it becomes real: the agent now receives the template's design brief and
  its exact theme JSON. Without this, every deck looked the same regardless of which of
  the 46 covers you picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DCjqvx3L4VKAPnFaPe7YJ