### PR TITLE
Fix the deck.json contract: decks rendered blank

### DIFF
--- a/kits/slides/app/package-lock.json
+++ b/kits/slides/app/package-lock.json
@@ -13,7 +13,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1",
-        "reifyui": "^0.4.0",
+        "reifyui": "^0.4.1",
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
@@ -3895,9 +3895,9 @@
       }
     },
     "node_modules/reifyui": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/reifyui/-/reifyui-0.4.0.tgz",
-      "integrity": "sha512-oTWv2ZBtb0QJ10ZHkBX6lbkzIC1cFS8Mrca8huxjq2c3fJkYOxK1Rrtiwj/GQPQPz15CH2kpaAiRIjdAE5VoNg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/reifyui/-/reifyui-0.4.1.tgz",
+      "integrity": "sha512-iAuaGpT/+GX1WcxYj8FDxxNv5qraVuAyXyHETiFArsIi88924MFPccXtKamerrOeFxQCWvZL/ptnuOJ3alzmVg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/kits/slides/app/package.json
+++ b/kits/slides/app/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "reifyui": "^0.4.0",
+    "reifyui": "^0.4.1",
     "echarts": "^5.5.1",
     "mermaid": "^11.4.1",
     "highlight.js": "^11.10.0",

--- a/kits/slides/app/src/lib/copilot.js
+++ b/kits/slides/app/src/lib/copilot.js
@@ -42,12 +42,22 @@ export async function streamTurn(deckId, message, h) {
     if (templateId && templateId !== 'blank') {
       const t = await getTemplateDetail(templateId).catch(() => null);
       if (t) {
+        // Two real slides from the template, verbatim. The theme alone only fixes the colours —
+        // these carry the layout system (grid, type scale, accent move) AND demonstrate the exact
+        // element shape, which is the thing a deck gets wrong in a way that renders blank.
+        const exemplars = (t.slides || []).slice(0, 2);
         input = [
           `Design this deck in the "${t.name}" style.`,
           t.context || t.description || '',
           '',
           'Use exactly this theme in deck.json:',
           JSON.stringify(t.theme || {}, null, 2),
+          ...(exemplars.length ? [
+            '',
+            'Follow these slides from the template — match their grid, type scale and accent'
+            + ' treatment, and copy their element shape exactly:',
+            JSON.stringify(exemplars, null, 2),
+          ] : []),
           '',
           `The brief: ${message}`,
         ].filter(Boolean).join('\n');

--- a/kits/slides/app/src/lib/sl.js
+++ b/kits/slides/app/src/lib/sl.js
@@ -157,10 +157,12 @@ export async function sendChat(id, message) {
   }));
 }
 
+/** The conversation so far: `{ turns }`, oldest first — the shape ChatPanel destructures.
+ *  The route is /turns; there is no /events, and calling one 404s history away silently. */
 export async function chatHistory(id) {
-  if (!id || String(id).startsWith('new:')) return [];
-  const body = await hr(`/sessions/${encodeURIComponent(id)}/events`).catch(() => null);
-  return body?.events ?? body?.data ?? [];
+  if (!id || String(id).startsWith('new:')) return { turns: [] };
+  const body = await hr(`/sessions/${encodeURIComponent(id)}/turns`).catch(() => null);
+  return { turns: body?.turns ?? [] };
 }
 
 /** Attachments land in the session workspace, where the agent can open them by name. */

--- a/kits/slides/skills/slide-design/SKILL.md
+++ b/kits/slides/skills/slide-design/SKILL.md
@@ -53,8 +53,8 @@ Non-negotiable, because each of these silently renders nothing:
   edit so the canvas keeps selection; never renumber a whole deck.
 - Paint order IS z-order: later elements in `elements[]` sit on top. There is
   no `z` property.
-- `type` is one of `text`, `shape`, `image`, `table`, `chart`, `diagram`,
-  `code`. Shapes carry their colour in `style.fill`; images use
+- `type` is one of `text`, `shape`, `image`, `table`, `chart`, `flowchart`,
+  `code`, `embed`. Shapes carry their colour in `style.fill`; images use
   `content.src` + `content.alt` + `content.fit`.
 
 Read `deck.json` before every change and write it back WHOLE. It is the single
@@ -162,7 +162,18 @@ Decide ONCE, before building — then every slide obeys it:
 
 ## 4. Review pass (mandatory)
 
-Reread the file you just wrote, as a designer:
+FIRST, check it renders at all. From your working directory:
+
+```
+python3 ~/.harness/skills/slide_design/validate_deck.py deck.json
+```
+
+It prints the exact path of anything the renderer will drop, and what to write
+instead. **Fix and re-run until it exits clean** — a deck that fails this
+renders as blank coloured rectangles for the user, and you cannot see that from
+here. Never end a turn on a failing deck.
+
+Then reread the file you just wrote, as a designer:
 - Consistent title positions/sizes across sibling slides? Same margins?
 - Any slide with > 5 elements or > 60% coverage → split or cut.
 - Any orphan default styling (wrong ink on custom background)?

--- a/kits/slides/skills/slide-design/SKILL.md
+++ b/kits/slides/skills/slide-design/SKILL.md
@@ -7,6 +7,59 @@ description: How to plan and design presentation decks — content architecture 
 
 You are designing a presentation, not filling a form.
 
+## The file you are writing
+
+There are no slide tools here. A deck is ONE file — `deck.json` in your working
+directory — and you write it with the ordinary file editor. Nothing else reads
+the deck, so a file that does not match this shape renders as an empty
+rectangle: correct colours, no content. Match it exactly.
+
+```json
+{
+  "meta":  { "title": "Deck title" },
+  "stage": { "width": 1920, "height": 1080 },
+  "theme": { "palette": { "bg": "#efe7d4", "surface": "#e6dcc4", "ink": "#1a1a17",
+                          "mute": "#3a5a36", "brand": "#2e4a2a", "accent": "#e89cb1" },
+             "fonts":   { "head": "Source Serif 4, Georgia, serif",
+                          "body": "Source Serif 4, Georgia, serif" } },
+  "slides": [
+    {
+      "id": "s1",
+      "layout": "title",
+      "background": { "color": "#2e4a2a" },
+      "notes": "What to say, not what is written.",
+      "elements": [
+        { "id": "s1-title", "type": "text",
+          "frame": { "x": 160, "y": 400, "w": 1600, "h": 200, "rotation": 0 },
+          "style": { "fontSize": 120, "color": "#efe7d4" },
+          "content": { "role": "title", "runs": [ { "text": "The Step 3 Cliff" } ] } },
+        { "id": "s1-rule", "type": "shape",
+          "frame": { "x": 160, "y": 640, "w": 160, "h": 8, "rotation": 0 },
+          "style": { "fill": "#e89cb1" } }
+      ]
+    }
+  ]
+}
+```
+
+Non-negotiable, because each of these silently renders nothing:
+
+- Position lives in **`frame`** — `{x, y, w, h, rotation}` in stage pixels.
+  Never `x`/`y`/`w`/`h` at the top level of an element.
+- Text lives in **`content.runs`**, an ARRAY of `{ "text": "..." }` objects.
+  Never a bare string. `role` is one of `title`, `subtitle`, `body`,
+  `bullets`, `caption`; for `bullets`, each run is one bullet.
+- Every slide and every element needs a stable **`id`**. Reuse ids when you
+  edit so the canvas keeps selection; never renumber a whole deck.
+- Paint order IS z-order: later elements in `elements[]` sit on top. There is
+  no `z` property.
+- `type` is one of `text`, `shape`, `image`, `table`, `chart`, `diagram`,
+  `code`. Shapes carry their colour in `style.fill`; images use
+  `content.src` + `content.alt` + `content.fit`.
+
+Read `deck.json` before every change and write it back WHOLE. It is the single
+source of truth and the person may have edited it on the canvas between turns.
+
 ## 0. Reference documents (when present)
 
 If the user attached documents, they are in your working directory (ls to find
@@ -19,13 +72,12 @@ them). Read them BEFORE planning — they are the starting point, not garnish:
 - From the reference, extract TWO plans: (a) **content** — reuse its actual
   facts, numbers, product names, and slide order as the base outline, updated
   per the user's ask; (b) **style** — derive the deck theme from its brand
-  colors/fonts (set_theme with a custom theme object), so the new deck reads
+  colors/fonts (write it into `theme`), so the new deck reads
   as the same brand, then apply this skill's craft rules on top.
 - Reuse the reference's IMAGES: a PPTX's pictures live in `_ref/ppt/media/`.
   Pick the meaningful ones (logo, product shots — not decorations), crop or
-  clean them in your workspace if needed (Pillow is available; or
-  generate_image for a fresh variant), then `import_image` the bytes and place
-  them — a brand logo on the cover instantly grounds the deck.
+  clean them in your workspace if needed (Pillow is available; or generate one with the imagegen skill), then reference them from an image element's `content.src`
+  by workspace-relative path — a brand logo on the cover instantly grounds the deck.
 - Tell the user in one line what you extracted (e.g. "Working from your intro
   deck: 12 slides, brand navy #0B2A4A + orange accent").
 
@@ -33,7 +85,7 @@ them). Read them BEFORE planning — they are the starting point, not garnish:
 
 If the deck already contains DESIGNED starter slides (a rich template — you
 can tell: multiple styled slides with placeholder editorial copy), that IS the
-style plan. Do NOT delete them or restyle: ADAPT in place — update_element
+style plan. Do NOT delete them or restyle: ADAPT in place — rewrite
 each text with the user's real content, keep every frame, accent shape, and
 type choice; delete only slides whose content type isn't needed; clone an
 existing slide's element pattern (matching x/w columns and fonts) when adding
@@ -65,8 +117,8 @@ build → review**. Never start adding slides before both plans exist.
 
 Decide ONCE, before building — then every slide obeys it:
 
-- **Theme**: pick or derive a palette that fits the mood (list_themes has
-  presets; set_theme accepts a full custom theme). Dark = dramatic/keynote,
+- **Theme**: pick or derive a palette that fits the mood (if the deck already
+  has a theme, keep it — it came from the template the user picked). Dark = dramatic/keynote,
   light = clean/business, warm = editorial/human. Set it FIRST so every slide
   inherits it. Slide backgrounds default to the theme — only override
   background for deliberate accents (a brand-colored section divider, a
@@ -83,7 +135,7 @@ Decide ONCE, before building — then every slide obeys it:
 
 ## 3. Build with craft
 
-- Build each slide with add_slide passing its full elements[] in ONE call.
+- Write the whole deck in one pass: every slide with its full `elements[]`.
 - **Title slides**: hero text ~y 400-500, subtitle under it, generous space.
   A gradient background ({gradient: "linear-gradient(135deg, <bg>, <surface>)"} 
   or brand-tinted) instantly lifts it.
@@ -105,12 +157,12 @@ Decide ONCE, before building — then every slide obeys it:
 - **Images**: use only when they carry meaning (product shot, hero mood);
   fit: "cover" inside a rounded frame (style.radius 16-24). Never stretch.
 - **Tables**: ≤ 5 columns; header row relies on the built-in brand rule.
-- Speaker notes: one tight paragraph per slide via set_notes — what to SAY,
-  not what's written.
+- Speaker notes: one tight paragraph per slide in the slide's `notes` — what
+  to SAY, not what's written.
 
 ## 4. Review pass (mandatory)
 
-get_deck and reread the result as a designer:
+Reread the file you just wrote, as a designer:
 - Consistent title positions/sizes across sibling slides? Same margins?
 - Any slide with > 5 elements or > 60% coverage → split or cut.
 - Any orphan default styling (wrong ink on custom background)?

--- a/kits/slides/skills/slide-design/validate_deck.py
+++ b/kits/slides/skills/slide-design/validate_deck.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Check deck.json against the contract the renderer actually enforces.
+
+A deck that is wrong in the wrong way does not fail loudly — it renders as an
+empty coloured rectangle, and the agent has no way to notice from inside the
+turn. That is what this exists for: run it after every write, and fix what it
+prints until it exits 0.
+
+Every rule here mirrors a real branch in the renderer (SlideView / ElementView
+in `reifyui/slides`): an element positions itself from `frame`, text comes from
+`content.runs`, and paint order comes from list order. If a rule below and the
+renderer ever disagree, the renderer is right and this file is the bug.
+
+    python3 validate_deck.py [deck.json]
+
+Exit 0 = renders. Exit 1 = something will be invisible or wrong.
+"""
+import json
+import sys
+
+STAGE_W, STAGE_H = 1920, 1080
+TYPES = {"text", "image", "chart", "flowchart", "shape", "table", "code", "embed"}  # = RENDERERS in reifyui/src/slides/elements.jsx
+ROLES = {"title", "subtitle", "body", "bullets", "caption"}
+MIN_FONT = 22
+
+errors: list[str] = []
+warnings: list[str] = []
+
+
+def err(where: str, what: str, fix: str) -> None:
+    errors.append(f"{where}: {what}\n    → {fix}")
+
+
+def warn(where: str, what: str, fix: str) -> None:
+    warnings.append(f"{where}: {what}\n    → {fix}")
+
+
+def check_element(el: object, where: str) -> None:
+    if not isinstance(el, dict):
+        err(where, "is not an object", "every element is a JSON object")
+        return
+
+    if not el.get("id"):
+        err(where, 'has no "id"',
+            'give it a stable id (e.g. "s2-title"); the canvas keeps selection by id')
+
+    t = el.get("type")
+    if t not in TYPES:
+        err(where, f'type {t!r} is not renderable',
+            f"use one of: {', '.join(sorted(TYPES))}")
+
+    # THE mistake. Top-level geometry is silently ignored: the element renders at
+    # 0×0 with no size, which looks like a blank slide.
+    stray = [k for k in ("x", "y", "w", "h", "width", "height") if k in el]
+    if stray:
+        err(where, f"has top-level {', '.join(stray)}",
+            'position goes in frame: {"x":…, "y":…, "w":…, "h":…, "rotation":0}')
+
+    if "z" in el:
+        err(where, 'has "z"',
+            "there is no z property — paint order is list order, so move the "
+            "element later in elements[] to raise it")
+
+    f = el.get("frame")
+    if not isinstance(f, dict):
+        err(where, 'has no "frame"',
+            'add frame: {"x":…, "y":…, "w":…, "h":…, "rotation":0} in stage pixels')
+    else:
+        for k in ("x", "y", "w", "h"):
+            v = f.get(k)
+            if not isinstance(v, (int, float)) or isinstance(v, bool):
+                err(f"{where}.frame", f"{k}={v!r} is not a number",
+                    "frame values are numbers in stage pixels (1920×1080)")
+        if isinstance(f.get("w"), (int, float)) and f["w"] <= 0:
+            err(f"{where}.frame", "w is not positive", "a zero-width element is invisible")
+        if isinstance(f.get("h"), (int, float)) and f["h"] <= 0:
+            err(f"{where}.frame", "h is not positive", "a zero-height element is invisible")
+        x, y = f.get("x"), f.get("y")
+        w, h = f.get("w"), f.get("h")
+        if all(isinstance(v, (int, float)) for v in (x, y, w, h)):
+            if x + w <= 0 or y + h <= 0 or x >= STAGE_W or y >= STAGE_H:
+                err(where, f"sits entirely off the {STAGE_W}×{STAGE_H} stage "
+                           f"(x={x}, y={y}, w={w}, h={h})",
+                    "move it onto the stage")
+            elif x < 0 or y < 0 or x + w > STAGE_W or y + h > STAGE_H:
+                warn(where, "extends past the stage edge", "keep a ≥120px margin")
+
+    c = el.get("content")
+    if t == "text":
+        if isinstance(c, str):
+            err(where, "content is a bare string",
+                'text lives in content.runs: {"role":"body","runs":[{"text":"…"}]}')
+        elif not isinstance(c, dict):
+            err(where, "has no content object",
+                'add content: {"role":"body","runs":[{"text":"…"}]}')
+        else:
+            runs = c.get("runs")
+            if not isinstance(runs, list) or not runs:
+                err(where, "content.runs is missing or empty",
+                    'runs is a non-empty array of {"text":"…"} objects')
+            else:
+                for i, r in enumerate(runs):
+                    if isinstance(r, str):
+                        err(f"{where}.content.runs[{i}]", "is a bare string",
+                            'each run is an object: {"text":"…"}')
+                    elif not isinstance(r, dict) or not isinstance(r.get("text"), str):
+                        err(f"{where}.content.runs[{i}]", "has no text string",
+                            'each run is {"text":"…"}')
+            role = c.get("role")
+            if role is not None and role not in ROLES:
+                warn(where, f"role {role!r} is not known",
+                     f"use one of: {', '.join(sorted(ROLES))}")
+        size = (el.get("style") or {}).get("fontSize")
+        if isinstance(size, (int, float)) and size < MIN_FONT:
+            warn(where, f"fontSize {size} is below {MIN_FONT}",
+                 "nothing under 22px is readable projected")
+    elif t == "image":
+        if not isinstance(c, dict) or not c.get("src"):
+            err(where, "image has no content.src",
+                'add content: {"src":"path/in/workspace.png","alt":"…","fit":"cover"}')
+    elif t == "shape":
+        if not (el.get("style") or {}).get("fill"):
+            warn(where, "shape has no style.fill",
+                 "it will fall back to the theme brand colour")
+
+
+def main() -> int:
+    path = sys.argv[1] if len(sys.argv) > 1 else "deck.json"
+    try:
+        with open(path) as fh:
+            deck = json.load(fh)
+    except FileNotFoundError:
+        print(f"{path} does not exist — write the deck first.")
+        return 1
+    except json.JSONDecodeError as e:
+        # Worth its own message: a truncated write is the other way a deck dies.
+        print(f"{path} is not valid JSON: {e}\n"
+              f"    → line {e.lineno}, column {e.colno}. Rewrite the file whole.")
+        return 1
+
+    if not isinstance(deck, dict):
+        print("deck.json must be a JSON object.")
+        return 1
+
+    slides = deck.get("slides")
+    if not isinstance(slides, list) or not slides:
+        err("deck", "has no slides[]", 'add "slides": [ … ] with at least one slide')
+        slides = []
+
+    theme = deck.get("theme")
+    if not isinstance(theme, dict) or not theme.get("palette"):
+        warn("deck", "has no theme.palette",
+             "slides fall back to defaults and lose the template's look")
+
+    seen: set[str] = set()
+    for i, s in enumerate(slides):
+        where = f"slides[{i}]"
+        if not isinstance(s, dict):
+            err(where, "is not an object", "every slide is a JSON object")
+            continue
+        sid = s.get("id")
+        if not sid:
+            err(where, 'has no "id"', 'give it a stable id (e.g. "s3")')
+        elif sid in seen:
+            err(where, f"reuses id {sid!r}", "slide ids must be unique")
+        else:
+            seen.add(str(sid))
+
+        els = s.get("elements")
+        if not isinstance(els, list):
+            err(where, "has no elements[]", 'add "elements": [ … ]')
+            continue
+        if not els:
+            warn(where, "has no elements", "an empty slide renders as a blank rectangle")
+        for j, el in enumerate(els):
+            check_element(el, f"{where}.elements[{j}]")
+        if len(els) > 8:
+            warn(where, f"has {len(els)} elements", "over ~8 reads as clutter; split the slide")
+
+    if errors:
+        print(f"{len(errors)} problem(s) that will render wrong:\n")
+        for e in errors:
+            print("  ✗ " + e)
+    if warnings:
+        print(f"\n{len(warnings)} warning(s):\n")
+        for w in warnings:
+            print("  ! " + w)
+    if not errors:
+        n = len(slides)
+        print(f"deck.json is valid — {n} slide{'s' if n != 1 else ''} will render."
+              + (" Review the warnings above." if warnings else ""))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Decks came out as empty coloured rectangles. The skill was carried over from the hosted product and referenced tools that do not exist in this kit (`add_slide`, `set_theme`, `get_deck`), and never stated the deck.json schema — so the agent invented one (`x/y/w/h` top-level, `content` as a bare string) and every element positioned nothing.

- skill now opens with the exact schema, a valid example, and the four failure modes that render silently
- execution verbs are file operations; design guidance untouched
- first turn carries two real template slides as layout + shape exemplars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DCjqvx3L4VKAPnFaPe7YJ