### PR TITLE
Trim the first-turn prompt; hide scaffolding from the chat

### DIFF
--- a/kits/slides/app/src/lib/copilot.js
+++ b/kits/slides/app/src/lib/copilot.js
@@ -34,32 +34,26 @@ export async function streamTurn(deckId, message, h) {
   const existing = deckId && !pending ? String(deckId) : '';
 
   // The template the person picked only exists client-side, so the first turn is where it becomes
-  // real: hand the agent the design brief and the exact theme to build on. Without this the
-  // choice would be silently discarded and every deck would come out looking the same.
-  let input = message;
+  // real. It rides in `instructions`, NOT in the message: the gateway records the raw user text
+  // for the transcript, so the chat keeps showing the sentence they typed instead of a wall of
+  // theme JSON. Scaffolding should be invisible.
+  let instructions = '';
   if (pending) {
     const templateId = String(deckId).slice(4);
     if (templateId && templateId !== 'blank') {
       const t = await getTemplateDetail(templateId).catch(() => null);
       if (t) {
-        // Two real slides from the template, verbatim. The theme alone only fixes the colours —
-        // these carry the layout system (grid, type scale, accent move) AND demonstrate the exact
-        // element shape, which is the thing a deck gets wrong in a way that renders blank.
-        const exemplars = (t.slides || []).slice(0, 2);
-        input = [
+        // The style brief and the theme, and nothing else. Embedding two full template slides as
+        // schema exemplars added ~10KB to the FIRST request and pushed deepseek-v4-pro past the
+        // runner's 90s no-first-token watchdog — the turn died having written nothing. The schema
+        // those exemplars were teaching now lives in the slide-design skill, where it costs
+        // nothing per turn and applies to every turn rather than only the first.
+        instructions = [
           `Design this deck in the "${t.name}" style.`,
           t.context || t.description || '',
           '',
           'Use exactly this theme in deck.json:',
           JSON.stringify(t.theme || {}, null, 2),
-          ...(exemplars.length ? [
-            '',
-            'Follow these slides from the template — match their grid, type scale and accent'
-            + ' treatment, and copy their element shape exactly:',
-            JSON.stringify(exemplars, null, 2),
-          ] : []),
-          '',
-          `The brief: ${message}`,
         ].filter(Boolean).join('\n');
       }
     }
@@ -69,7 +63,8 @@ export async function streamTurn(deckId, message, h) {
     method: 'POST',
     headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
     body: JSON.stringify({
-      input,
+      input: message,
+      ...(instructions ? { instructions } : {}),
       metadata: { harness_id: harness.id, ...(existing ? { session_id: existing } : {}) },
       stream: true,
     }),

--- a/kits/slides/app/src/lib/sl.js
+++ b/kits/slides/app/src/lib/sl.js
@@ -121,15 +121,14 @@ export async function deleteDeck(id) {
   return hr(`/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
-/** The deck JSON: { deck_id, deck }. Null deck means the agent has not written one yet. */
+/** The deck JSON: { deck_id, deck }. Null deck means the agent has not written one yet.
+ *
+ *  Read by path, which reads the LIVE workspace — so a deck appears as soon as the agent writes
+ *  it, mid-turn. The file listing next to it answers from the checkpoint tarball, which is only
+ *  written when a turn ends: polling that showed a spinner for a deck that was already on disk. */
 export async function getDeck(id) {
-  const doc = await hr(`/sessions/${encodeURIComponent(id)}/files`).catch(() => null);
-  const file = (doc?.files || []).find((f) => (f.path || f.filename) === 'deck.json');
-  if (!file) return { deck_id: id, deck: null };
-  const r = await fetch(
-    `${API}/containers/${encodeURIComponent(id)}/files/${encodeURIComponent(file.id)}/content`,
-    { cache: 'no-store' },
-  );
+  const r = await fetch(`${API}/sessions/${encodeURIComponent(id)}/files/deck.json`,
+                        { cache: 'no-store' });
   if (!r.ok) return { deck_id: id, deck: null };
   return { deck_id: id, deck: await r.json().catch(() => null) };
 }

--- a/kits/slides/app/src/pages/DeckPage.jsx
+++ b/kits/slides/app/src/pages/DeckPage.jsx
@@ -10,7 +10,7 @@ import { HelpCircle, Home, Maximize2, Download } from 'lucide-react';
 import { SlideView, EditorCanvas } from 'reifyui/slides';
 import { Presentation } from 'reifyui/slides';
 import { PaneResizer, useResizablePane } from 'reifyui';
-import { getDeck, saveDeck, markViewed, workspaceFileIndex } from '../lib/sl';
+import { chatHistory, deckStatus, getDeck, saveDeck, markViewed, workspaceFileIndex } from '../lib/sl';
 import { authFetch, getSession } from '../lib/auth';
 import { useDeckCollab } from '../lib/collab';
 import { ChatColumn } from '../components/ChatPanel';
@@ -80,6 +80,8 @@ export function DeckPage({ id, seed }) {
     onCopilot: setCopilotBusy,
   });
 
+  const [noDeck, setNoDeck] = useState(null);
+
   const adoptSession = useCallback((sid) => {
     if (!sid || sid === id) return;
     const [, query = ''] = (window.location.hash || '').split('?');
@@ -88,10 +90,31 @@ export function DeckPage({ id, seed }) {
     window.dispatchEvent(new HashChangeEvent('hashchange'));
   }, [id]);
 
+  // "No deck" is three different situations and they must not look alike. The deck only exists
+  // once a turn has written deck.json AND checkpointed, so a turn that is still going, and a turn
+  // that died having written nothing, both arrive here as `deck: null`. Reporting both as
+  // "Loading deck…" is how this page sat pretending to load a deck that was never coming.
   const load = useCallback(() => getDeck(id)
-    .then((r) => {
+    .then(async (r) => {
       revRef.current = Number(r.deck?.meta?.rev || 0);
       setDeckState(r.deck);
+      if (r.deck) { setNoDeck(null); return; }
+      const st = await deckStatus(id).catch(() => '');
+      if (['running', 'starting'].includes(st)) {
+        setNoDeck({ working: true, text: 'Designing your deck…' });
+        return;
+      }
+      // Finished without producing one: the turn's own last words are the only honest
+      // explanation we have, so show them rather than a generic failure.
+      const { turns } = await chatHistory(id).catch(() => ({ turns: [] }));
+      const last = turns[turns.length - 1];
+      setNoDeck({
+        working: false,
+        text: last?.status && last.status !== 'completed'
+          ? `The last turn ended as "${last.status}" without writing a deck.`
+          : 'No deck was written for this conversation yet.',
+        detail: String(last?.assistant || '').slice(0, 400),
+      });
     })
     .catch((e) => setErr(e.message || 'Could not open this deck.')), [id]);
 
@@ -243,7 +266,20 @@ export function DeckPage({ id, seed }) {
                 peers={collab.peers}
               />
             ) : (
-              <div className="empty-note" style={{ paddingTop: 80 }}>{deck ? 'This deck has no slides.' : 'Loading deck…'}</div>
+              <div className="empty-note" style={{ paddingTop: 80 }}>
+                {deck ? 'This deck has no slides.'
+                  : noDeck ? (
+                    <>
+                      <div>{noDeck.text}</div>
+                      {noDeck.detail && <pre className="deck-empty-detail">{noDeck.detail}</pre>}
+                      {!noDeck.working && (
+                        <div style={{ marginTop: 14 }}>
+                          Ask the copilot again on the right — the conversation is still here.
+                        </div>
+                      )}
+                    </>
+                  ) : 'Loading deck…'}
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
The first turn died with "This model produced no output within 90s" — two full template slides in the request pushed the model past the runner's no-first-token watchdog before it wrote anything.

- schema exemplars removed; the slide-design skill already carries the schema, at no per-turn cost
- style brief + theme move from `input` to `instructions`, so the chat shows what the user typed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DCjqvx3L4VKAPnFaPe7YJ