### PR TITLE
Poll for the deck; keep the design spec out of the user's message

### DIFF
--- a/kits/slides/app/src/pages/DeckPage.jsx
+++ b/kits/slides/app/src/pages/DeckPage.jsx
@@ -123,6 +123,17 @@ export function DeckPage({ id, seed }) {
     load();
   }, [id, load]);
 
+  // Keep looking while the agent is working. The deck is a file it writes DURING the turn, and
+  // reads now hit the live workspace, so slides appear as they are written instead of after the
+  // turn ends. Without this the page shows "Designing your deck…" over a deck that is already on
+  // disk — which is exactly what it did, because the only other refresh is the stream ending, and
+  // a reloaded tab has no stream.
+  useEffect(() => {
+    if (!noDeck?.working && deck) return undefined;
+    const t = window.setInterval(() => { void load(); }, 4000);
+    return () => window.clearInterval(t);
+  }, [noDeck?.working, deck, load]);
+
   // ── mutations: apply locally, push undo, schedule autosave ────────────────
   const scheduleSave = useCallback(() => {
     dirtyRef.current = true;

--- a/kits/slides/app/src/pages/Landing.jsx
+++ b/kits/slides/app/src/pages/Landing.jsx
@@ -11,7 +11,7 @@ import {
 import { SlideView } from 'reifyui/slides';
 import {
   subscribe, listTemplates, listDecks, createDeck, renameDeck, deleteDeck,
-  getTemplateDetail, getDeck, lastViewedMap, relativeTime, uploadRef,
+  getDeck, lastViewedMap, relativeTime, uploadRef,
 } from '../lib/sl';
 import { PROMPT_IDEAS } from '../lib/promptIdeas';
 import { Topbar } from '../components/Topbar';
@@ -168,10 +168,11 @@ export function LandingPage() {
           : (refFile ? refFile.name.replace(/\.[^.]+$/, '') : (tpl ? tpl.name : 'Untitled deck'));
         let seed = text || (refFile ? `Build a deck from the attached document ${refFile.name} — use it as the starting point for both content and style.`
           : `Design a ${tpl.name} deck.`);
-        if (tpl) {
-          const det = await getTemplateDetail(tpl.id);
-          seed += `\n\nUse this template as inspiration (adapt, don't copy): ${det.context}`;
-        }
+        // The template brief deliberately does NOT go in the seed. The seed becomes the user's
+        // chat message, and pasting a design spec into it means every widget that renders this
+        // conversation — this copilot, the console's task view, the trace — shows the person a
+        // wall of text they did not write. It travels as `instructions` instead (lib/copilot.js),
+        // which the gateway keeps out of the recorded user text.
         const res = await createDeck(name, tpl ? tpl.id : 'blank');
         if (refFile) {
           await uploadRef(res.id, refFile);

--- a/kits/slides/kit.json
+++ b/kits/slides/kit.json
@@ -14,7 +14,7 @@
       },
       {
         "base": "codex",
-        "model": "gpt-5.6-sol"
+        "model": "gpt-5.4-mini"
       },
       {
         "base": "claude-code",


### PR DESCRIPTION
Two defects from live screenshots:

- the page showed "Designing your deck…" over a `deck.json` that was already written and valid — the waiting state had nothing to leave it with, since the only refresh was the stream ending and a reloaded tab has no stream. It now polls while a turn runs, which is what reading the live workspace is for.
- the template brief was appended to the seed, i.e. the user's own chat message, so every chat widget showed a design spec the person never typed. Fixed at source: seed is their sentence; the brief travels as `instructions`.

Also drops the Codex recommendation from gpt-5.6-sol to gpt-5.4-mini on cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DCjqvx3L4VKAPnFaPe7YJ