### PR TITLE
Help and Documentation link to the slides kit

### DIFF
--- a/kits/slides/app/src/components/Topbar.jsx
+++ b/kits/slides/app/src/components/Topbar.jsx
@@ -9,7 +9,9 @@ import { getSession, logout, SESSION_EVENT } from '../lib/auth';
 import { SlMark } from './SlMark';
 
 export const LINKS = {
-  docs: 'https://github.com/HarnessRouter/starter-kit',
+  // The kit's own folder, not the repository root — someone asking this app for help wants the
+  // Slides README and its skill, not a list of every starter kit.
+  docs: 'https://github.com/HarnessRouter/starter-kit/tree/main/kits/slides',
 };
 
 export function Wordmark({ size = 18 }) {


### PR DESCRIPTION
Both the account menu's Documentation entry and the deck page's help button pointed at the repository root. They now open `kits/slides`, which is what someone asking this app for help actually wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DCjqvx3L4VKAPnFaPe7YJ