### PR TITLE
Fix mid-stream blank copilot, show the chosen template, skeleton the wait

### DIFF
--- a/kits/slides/app/src/App.jsx
+++ b/kits/slides/app/src/App.jsx
@@ -1,6 +1,6 @@
 // Hash router.
 //   #/            landing (prompt, templates, my slides)
-//   #/d/{id}      deck page (optionally ?seed=<first copilot message>)
+//   #/d/{id}      deck page (?seed=<first copilot message>, ?tpl=<template the deck came from>)
 //   #/print       print view
 //
 // The hosted product also routes #/login and keeps a sliding JWT alive here. This build has
@@ -17,7 +17,8 @@ function parseHash() {
   const params = new URLSearchParams(query);
   if (path === 'print') return { page: 'print' };
   if (path.startsWith('d/')) {
-    return { page: 'deck', id: decodeURIComponent(path.slice(2)), seed: params.get('seed') || '' };
+    return { page: 'deck', id: decodeURIComponent(path.slice(2)),
+             seed: params.get('seed') || '', template: params.get('tpl') || '' };
   }
   return { page: 'landing' };
 }
@@ -32,6 +33,8 @@ export default function App() {
   }, []);
 
   if (route.page === 'print') return <PrintPage />;
-  if (route.page === 'deck') return <DeckPage key={route.id} id={route.id} seed={route.seed} />;
+  if (route.page === 'deck') {
+    return <DeckPage key={route.id} id={route.id} seed={route.seed} template={route.template} />;
+  }
   return <LandingPage />;
 }

--- a/kits/slides/app/src/components/ChatPanel.jsx
+++ b/kits/slides/app/src/components/ChatPanel.jsx
@@ -177,7 +177,18 @@ export function ChatColumn({ deckId, seed, title, copilotBuilding, collapsed, on
   }
 
   // Mount: strip ?seed FIRST, then replay history; seed fires only when empty.
+  //
+  // Keyed on deckId, and a pending deck CHANGES its id mid-stream: it starts as "new:<template>"
+  // and adopts the real session id the moment the first turn opens one. Re-running then refetched
+  // history and setMessages() over the blocks that were streaming in — the panel showed the user
+  // bubble and nothing else while the console showed the whole turn. It is the same conversation,
+  // so the resolve is not a reason to reload it.
+  const prevDeckId = useRef(deckId);
   useEffect(() => {
+    const resolved = String(prevDeckId.current || '').startsWith('new:')
+      && !String(deckId || '').startsWith('new:');
+    prevDeckId.current = deckId;
+    if (resolved) return undefined;
     stripSeedFromHash();
     let dead = false;
     chatHistory(deckId).then(({ turns }) => {

--- a/kits/slides/app/src/components/Skeleton.jsx
+++ b/kits/slides/app/src/components/Skeleton.jsx
@@ -120,3 +120,26 @@ export function SkeletonTableRows({ count = 6 }) {
     </>
   );
 }
+
+/** The deck page while the agent is still writing deck.json.
+ *
+ *  Shaped like the thing that is coming — a filmstrip of slide thumbs beside a 16:9 stage — so the
+ *  wait reads as "your deck is being built here" rather than as an empty pane with a sentence in
+ *  it. The slide count is NOT guessed: four placeholders is the shape of the layout, not a claim
+ *  about how many slides you will get, so nothing here can turn out to be wrong.
+ */
+export function SkeletonDeck({ note }) {
+  return (
+    <div className="sk-deck" aria-busy="true" aria-live="polite">
+      <div className="sk-deck-rail" aria-hidden="true">
+        {[0, 1, 2, 3].map((i) => (
+          <span key={i} className="sk-deck-thumb"><Skeleton variant="thumbnail" /></span>
+        ))}
+      </div>
+      <div className="sk-deck-stage">
+        <Skeleton variant="thumbnail" className="sk-deck-slide" />
+        {note && <p className="sk-deck-note">{note}</p>}
+      </div>
+    </div>
+  );
+}

--- a/kits/slides/app/src/pages/DeckPage.jsx
+++ b/kits/slides/app/src/pages/DeckPage.jsx
@@ -10,11 +10,13 @@ import { HelpCircle, Home, Maximize2, Download } from 'lucide-react';
 import { SlideView, EditorCanvas } from 'reifyui/slides';
 import { Presentation } from 'reifyui/slides';
 import { PaneResizer, useResizablePane } from 'reifyui';
-import { chatHistory, deckStatus, getDeck, saveDeck, markViewed, workspaceFileIndex } from '../lib/sl';
+import { chatHistory, deckStatus, getDeck, getTemplateDetail, saveDeck, markViewed,
+         workspaceFileIndex } from '../lib/sl';
 import { authFetch, getSession } from '../lib/auth';
 import { useDeckCollab } from '../lib/collab';
 import { ChatColumn } from '../components/ChatPanel';
 import { AvatarMenu, LINKS, Wordmark } from '../components/Topbar';
+import { SkeletonDeck } from '../components/Skeleton';
 
 // Images the agent made live in the session workspace, so a deck's `src` is a path there rather
 // than a URL. Resolve it against the session's file list; until that arrives, leave the path
@@ -50,7 +52,7 @@ async function downloadExport(id, title, kind, setBusy) {
   } finally { setBusy(''); }
 }
 
-export function DeckPage({ id: routeId, seed }) {
+export function DeckPage({ id: routeId, seed, template }) {
   // The session id lives in state, not in the route. A deck starts as "new:<template>" and
   // becomes a session when its first turn opens one — and that arrives WHILE the copilot is
   // streaming. Re-keying this component off the URL at that moment unmounted it mid-stream and
@@ -87,6 +89,17 @@ export function DeckPage({ id: routeId, seed }) {
   });
 
   const [noDeck, setNoDeck] = useState(null);
+  // The template the deck was created from. Its brief travels invisibly in `instructions`, but the
+  // CHOICE is the person's and they should be able to see it — including after a reload.
+  const [tplName, setTplName] = useState('');
+  useEffect(() => {
+    if (!template) { setTplName(''); return undefined; }
+    let dead = false;
+    getTemplateDetail(template)
+      .then((t) => { if (!dead) setTplName(t?.name || ''); })
+      .catch(() => {});
+    return () => { dead = true; };
+  }, [template]);
 
   const adoptSession = useCallback((sid) => {
     if (!sid || sid === id) return;
@@ -284,20 +297,22 @@ export function DeckPage({ id: routeId, seed }) {
                 peers={collab.peers}
               />
             ) : (
-              <div className="empty-note" style={{ paddingTop: 80 }}>
-                {deck ? 'This deck has no slides.'
-                  : noDeck ? (
-                    <>
-                      <div>{noDeck.text}</div>
-                      {noDeck.detail && <pre className="deck-empty-detail">{noDeck.detail}</pre>}
-                      {!noDeck.working && (
-                        <div style={{ marginTop: 14 }}>
-                          Ask the copilot again on the right — the conversation is still here.
-                        </div>
-                      )}
-                    </>
-                  ) : 'Loading deck…'}
-              </div>
+              deck ? (
+                <div className="empty-note" style={{ paddingTop: 80 }}>This deck has no slides.</div>
+              ) : noDeck && !noDeck.working ? (
+                <div className="empty-note" style={{ paddingTop: 80 }}>
+                  <div>{noDeck.text}</div>
+                  {noDeck.detail && <pre className="deck-empty-detail">{noDeck.detail}</pre>}
+                  <div style={{ marginTop: 14 }}>
+                    Ask the copilot again on the right — the conversation is still here.
+                  </div>
+                </div>
+              ) : (
+                // Still coming: show the shape of a deck rather than a sentence in an empty pane.
+                <SkeletonDeck note={noDeck?.working
+                  ? (tplName ? `Designing your deck in ${tplName}…` : 'Designing your deck…')
+                  : 'Loading deck…'} />
+              )
             )}
           </div>
         </div>

--- a/kits/slides/app/src/pages/Landing.jsx
+++ b/kits/slides/app/src/pages/Landing.jsx
@@ -19,9 +19,15 @@ import { Dialog, ConfirmDialog } from '../components/Dialog';
 import { TemplatePreviewModal } from '../components/TemplatePreviewModal';
 import { SkeletonTableRows, SkeletonTemplateCards } from '../components/Skeleton';
 
-function openDeck(id, seed) {
-  const q = seed ? `?seed=${encodeURIComponent(seed)}` : '';
-  window.location.hash = `#/d/${id}${q}`;
+function openDeck(id, seed, template) {
+  // `seed` is consumed and stripped on arrival; `template` stays, because it is a property of the
+  // deck the person created and they should be able to see which one they picked — including
+  // after a reload.
+  const q = new URLSearchParams();
+  if (seed) q.set('seed', seed);
+  if (template && template !== 'blank') q.set('tpl', template);
+  const qs = q.toString();
+  window.location.hash = `#/d/${id}${qs ? `?${qs}` : ''}`;
 }
 
 function useTypewriter(active) {
@@ -178,7 +184,7 @@ export function LandingPage() {
           await uploadRef(res.id, refFile);
           if (text) seed += `\n\nI attached ${refFile.name} — use it as the starting point for both content and style.`;
         }
-        openDeck(res.id, seed);
+        openDeck(res.id, seed, tpl ? tpl.id : '');
       } catch (e) { setCreating(false); setCreateErr(e.message || 'Could not create the deck.'); }
     });
   }

--- a/kits/slides/app/src/styles/app.css
+++ b/kits/slides/app/src/styles/app.css
@@ -836,3 +836,22 @@
   font-size: 13px; font-family: inherit; color: var(--ink); padding: 8px 10px; border-radius: 7px;
 }
 .sl-export-menu button:hover { background: var(--surface-2, var(--brand-50)); color: var(--brand); }
+
+/* ── Deck skeleton: the shape of a deck page while the agent writes deck.json ─── */
+.sk-deck { display: flex; flex: 1; min-height: 0; }
+.sk-deck-rail {
+  flex: 0 0 168px; display: flex; flex-direction: column; gap: 10px;
+  padding: 12px; border-right: 1px solid var(--line); overflow: hidden;
+}
+.sk-deck-thumb { display: block; width: 100%; aspect-ratio: 16/9; }
+.sk-deck-thumb .sk { display: block; width: 100%; height: 100%; border-radius: 6px; }
+.sk-deck-stage {
+  flex: 1; min-width: 0; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 16px; padding: 28px; background: var(--bg);
+}
+/* 16:9, capped so it never outgrows the pane — the same box the real stage occupies. */
+.sk-deck-slide {
+  width: min(100%, 980px); aspect-ratio: 16/9; height: auto !important; border-radius: 10px;
+}
+.sk-deck-note { margin: 0; font-size: 13px; color: var(--mute); }
+@media (max-width: 820px) { .sk-deck-rail { display: none; } }

--- a/kits/slides/kit.json
+++ b/kits/slides/kit.json
@@ -21,7 +21,7 @@
         "model": "claude-opus-5"
       }
     ],
-    "system_prompt": "You design and edit presentation decks. The deck is deck.json in your working directory \u2014 the single source of truth, and the only file the app reads. Read it before every change and write it back whole. Follow the slide-design skill for every deck request, before touching deck.json.",
+    "system_prompt": "You design and edit presentation decks.\n\nTHE FILE: ./deck.json, in your current working directory. That exact path, always. Do not search for it, do not look elsewhere in the tree, and do not treat its absence as a puzzle \u2014 on a new deck it simply does not exist yet and you create it there. It is the single source of truth and the only file the app reads.\n\nRead it before every change and write it back whole. Its schema, and the four mistakes that render as an empty rectangle, are in the slide-design skill \u2014 read that skill first, on every deck request, and validate with its validate_deck.py before you finish.\n\nWork directly. Every command you spend orienting is a command the person waits through.",
     "skills": [
       "slide-design"
     ]


### PR DESCRIPTION
From live screenshots:

- **Streaming died on the first turn.** ChatPanel reloads history keyed on `deckId`, and a pending deck changes its id mid-stream when the first turn opens a session — the refetch overwrote the blocks arriving live.
- **The template was invisible.** Its brief correctly moved to `instructions`, but that also erased any sign a template was picked. It now rides in the deck URL and the waiting state names it.
- **The wait was a bare sentence.** Now a skeleton shaped like a deck. The placeholder count is the layout's shape, not a claim about slide count.
- **The agent hunted for deck.json.** The system prompt now names the exact path, removing commands the person waits through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DCjqvx3L4VKAPnFaPe7YJ