### PR TITLE
Deleting a deck did nothing; renaming did nothing

### DIFF
--- a/kits/slides/app/src/lib/sl.js
+++ b/kits/slides/app/src/lib/sl.js
@@ -117,8 +117,15 @@ export async function renameDeck(id, name) {
   return hr(`/sessions/${encodeURIComponent(id)}`, jsonInit('PATCH', { title: name }));
 }
 
+/** Delete the deck AND the conversation underneath it.
+ *
+ *  The route is /traces/{id}, not /sessions/{id} — there is no DELETE on the session path, so the
+ *  obvious call silently did nothing and the deck came back on the next load. This one removes the
+ *  trace, the durable workspace tarball (deck.json included) and tombstones the session, which is
+ *  what "delete" has to mean here: a deck IS its session, so leaving the session behind would
+ *  leave the deck recoverable and the storage held. */
 export async function deleteDeck(id) {
-  return hr(`/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  return hr(`/traces/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
 /** The deck JSON: { deck_id, deck }. Null deck means the agent has not written one yet.


### PR DESCRIPTION
Both called routes that do not exist — the request 404'd, the catch swallowed it, and the card came back on the next load.

- **Delete** now calls `DELETE /traces/{id}`, which already removes the trace, the durable workspace tarball (deck.json included) and tombstones the session. A deck *is* its session, so leaving the session behind would leave the deck recoverable and the storage held.
- **Rename** needed a route; `PATCH /v1/sessions/{sid}` is added on the gateway side.

Fourth dead endpoint found one screenshot at a time, so I enumerated every path the kit calls against the routes that exist. All eleven resolve now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DCjqvx3L4VKAPnFaPe7YJ